### PR TITLE
Correlation ID

### DIFF
--- a/todo-backend-springboot/src/main/kotlin/epo/todo/backend/config/CorrelationInterceptor.kt
+++ b/todo-backend-springboot/src/main/kotlin/epo/todo/backend/config/CorrelationInterceptor.kt
@@ -1,0 +1,49 @@
+package epo.todo.backend.config
+
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter
+import java.util.UUID
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Implementation of [HandlerInterceptorAdapter] that attaches a correlation ID to SLF4J's MDC
+ * (Mapped Diagnostic Context) when a REST endpoint is called. If one is provided as a header
+ * then it will be used; otherwise, a new one will be created.
+ * When the controller returns a response, the correlation ID will be removed from the MDC.
+ */
+@Component
+class CorrelationInterceptor : HandlerInterceptorAdapter() {
+
+    override fun preHandle(request: HttpServletRequest,
+                           response: HttpServletResponse,
+                           handler: Any): Boolean {
+        val correlationId = getCorrelationIdFromHeader(request)
+        MDC.put(CORRELATION_ID_LOG_VAR_NAME, correlationId)
+        return true
+    }
+
+    override fun afterCompletion(request: HttpServletRequest,
+                                 response: HttpServletResponse,
+                                 handler: Any,
+                                 ex: Exception?) {
+        MDC.remove(CORRELATION_ID_LOG_VAR_NAME)
+    }
+
+    private fun getCorrelationIdFromHeader(request: HttpServletRequest): String {
+        return try {
+            // It's a bit counter intuitive to call fromString and then toString, but by calling UUID.fromString(),
+            // the string gets automatically validated. Any string that is not in a valid UUID format will
+            // cause an IllegalArgumentException to be thrown, which allows us to assign a new one instead.
+            UUID.fromString(request.getHeader(CORRELATION_ID_HEADER_NAME)).toString()
+        } catch (e: Exception) {
+            UUID.randomUUID().toString()
+        }
+    }
+
+    companion object {
+        private const val CORRELATION_ID_HEADER_NAME = "X-Correlation-Id"
+        private const val CORRELATION_ID_LOG_VAR_NAME = "correlationId"
+    }
+}

--- a/todo-backend-springboot/src/main/kotlin/epo/todo/backend/config/CorrelationInterceptor.kt
+++ b/todo-backend-springboot/src/main/kotlin/epo/todo/backend/config/CorrelationInterceptor.kt
@@ -36,8 +36,8 @@ class CorrelationInterceptor : HandlerInterceptorAdapter() {
             // It's a bit counter intuitive to call fromString and then toString, but by calling UUID.fromString(),
             // the string gets automatically validated. Any string that is not in a valid UUID format will
             // cause an IllegalArgumentException to be thrown, which allows us to assign a new one instead.
-            UUID.fromString(request.getHeader(CORRELATION_ID_HEADER_NAME)).toString()
-        } catch (e: Exception) {
+            UUID.fromString(request.getHeader(CORRELATION_ID_HEADER_NAME) ?: "").toString()
+        } catch (e: IllegalArgumentException) {
             UUID.randomUUID().toString()
         }
     }

--- a/todo-backend-springboot/src/main/kotlin/epo/todo/backend/config/WebMvcConfig.kt
+++ b/todo-backend-springboot/src/main/kotlin/epo/todo/backend/config/WebMvcConfig.kt
@@ -1,0 +1,15 @@
+package epo.todo.backend.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * A [WebMvcConfigurer] used for adding custom handler interceptors.
+ */
+@Configuration
+class WebMvcConfig(val correlationInterceptor: CorrelationInterceptor) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(correlationInterceptor)
+    }
+}

--- a/todo-backend-springboot/src/main/kotlin/epo/todo/backend/exception/ApiError.kt
+++ b/todo-backend-springboot/src/main/kotlin/epo/todo/backend/exception/ApiError.kt
@@ -3,13 +3,14 @@ package epo.todo.backend.exception
 import com.fasterxml.jackson.annotation.JsonFormat
 import org.springframework.http.HttpStatus
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Data class used for custom error response bodies.
  */
 data class ApiError(val status: HttpStatus,
-                    val message: String = "Unexpected error",
-                    var debugMessage: String? = null) {
+                    val message: String,
+                    val correlationId: UUID) {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private val timestamp: Instant = Instant.now()

--- a/todo-backend-springboot/src/main/kotlin/epo/todo/backend/exception/RestExceptionHandler.kt
+++ b/todo-backend-springboot/src/main/kotlin/epo/todo/backend/exception/RestExceptionHandler.kt
@@ -1,11 +1,13 @@
 package epo.todo.backend.exception
 
 import mu.KotlinLogging
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import java.util.UUID
 
 /**
  * Class that intercepts exceptions thrown by code called by REST controllers.
@@ -20,31 +22,40 @@ class RestExceptionHandler : ResponseEntityExceptionHandler() {
      * Extension function joining all stack trace elements to a single string
      * for simple stack trace logging.
      */
-    fun java.lang.Exception.prettyStackTrace(): String = this.stackTrace.asList().joinToString(separator = "\n")
+    fun java.lang.Exception.prettyStackTrace(): String = this.stackTrace.asList().joinToString(separator = "\nat ")
 
     private fun logException(ex: Exception) {
         log.error { ex.message }
         log.error { ex.prettyStackTrace() }
     }
 
+    private fun buildResponse(status: HttpStatus, message: String?): ResponseEntity<ApiError> {
+        val apiError = ApiError(status = status,
+                                message = message ?: UNEXPECTED_ERROR,
+                                correlationId = UUID.fromString(MDC.get(CORRELATION_ID_LOG_VAR_NAME)))
+        return ResponseEntity(apiError, status)
+    }
+
     @ExceptionHandler(value = [BadRequestException::class])
     fun handleException(ex: BadRequestException): ResponseEntity<ApiError> {
-        val apiError = ApiError(HttpStatus.BAD_REQUEST, ex.message!!)
-        return ResponseEntity(apiError, apiError.status)
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.message)
                 .also { logException(ex) }
     }
 
     @ExceptionHandler(value = [NotFoundException::class])
     fun handleException(ex: NotFoundException): ResponseEntity<ApiError> {
-        val apiError = ApiError(HttpStatus.NOT_FOUND, ex.message!!)
-        return ResponseEntity(apiError, apiError.status)
+        return buildResponse(HttpStatus.NOT_FOUND, ex.message)
                 .also { logException(ex) }
     }
 
     @ExceptionHandler(value = [Exception::class])
     fun handleException(ex: Exception): ResponseEntity<ApiError> {
-        val apiError = ApiError(HttpStatus.INTERNAL_SERVER_ERROR)
-        return ResponseEntity(apiError, apiError.status)
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.message)
                 .also { logException(ex) }
+    }
+
+    companion object {
+        private const val CORRELATION_ID_LOG_VAR_NAME = "correlationId"
+        private const val UNEXPECTED_ERROR = "Unexpected error"
     }
 }

--- a/todo-backend-springboot/src/main/resources/logback.xml
+++ b/todo-backend-springboot/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!--        PatternLayoutEncoder is the default, but keeping it there for clarity-->
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%yellow(%d{HH:mm:ss.SSS} [%thread]) %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
+            <pattern>%yellow(%d{HH:mm:ss.SSS} [%thread]) %magenta([%X{correlationId}]) %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
         </encoder>
     </appender>
 
@@ -14,5 +14,4 @@
     <root level="error">
         <appender-ref ref="STDOUT"/>
     </root>
-
 </configuration>


### PR DESCRIPTION
Added support for correlation ID in http headers and error responses. An interceptor automatically sets the provided correlation ID to the MDC or assigns a new one to it on every API call.